### PR TITLE
Implement revised contract in PHPDBG Driver

### DIFF
--- a/src/Driver/PHPDBG.php
+++ b/src/Driver/PHPDBG.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of the php-code-coverage package.
  *
  * (c) Sebastian Bergmann <sebastian@phpunit.de>
@@ -97,6 +97,13 @@ final class PHPDBG implements Driver
                     $sourceLines[$file][$lineNo] = self::LINE_EXECUTED;
                 }
             }
+        }
+
+        foreach ($sourceLines as $file => $lines) {
+            $sourceLines[$file] = [
+                'lines' => $lines,
+                'functions' => []
+            ];
         }
 
         return $sourceLines;


### PR DESCRIPTION
`detectExecutedLines` didn't seem like the correct place for this at first, but the `Convert phpdbg based data into the format CodeCoverage expects` comment convinced me otherwise.

Addresses #19