### PR TITLE
Default determineBranchCoverage to false (makes current tests pass again)

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -134,9 +134,11 @@ final class CodeCoverage
     private $report;
 
     /**
+     * Determine whether to display branch coverage
+     *
      * @var bool
      */
-    private $determineBranchCoverage;
+    private $determineBranchCoverage = false;
 
     /**
      * @throws RuntimeException


### PR DESCRIPTION
This just defaults CodeCoverage::determineBranchCoverage to false, which makes the xdebug portion of the tests pass again.

Line 250 (now 252) was passing `null`, causing the tests to fail.

```php
$this->driver->setDetermineBranchCoverage($this->determineBranchCoverage);
```